### PR TITLE
Make it run on Python 3.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,12 @@ python:
     - 3.4
     - 3.5
     - 3.6
+    - 3.12
 
 env:
     - DJANGO='django>=1.10,<1.11'
     - DJANGO='django>=1.11,<2.0'
-    - DJANGO='django>=2.0,<2.2'
+    - DJANGO='django>=2.0,<2.3'
 
 install:
     - travis_retry pip install $DJANGO

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@
 
 1.2 Зависимости.  
 - Требуется Python не ниже версии 3.4
-- Django 1.10
-- Pillow 2.9.0
+- Django 2.2
+- Pillow 10.0
 - apscheduler 3.3.0
 - django-picklefield
 - lxml

--- a/opds_catalog/zipf.py
+++ b/opds_catalog/zipf.py
@@ -6,7 +6,7 @@ XXX references to utf-8 need further investigation.
 import io
 import os
 import re
-import imp
+import importlib
 import sys
 import time
 import stat
@@ -1647,8 +1647,8 @@ class PyZipFile(ZipFile):
         file_py  = pathname + ".py"
         file_pyc = pathname + ".pyc"
         file_pyo = pathname + ".pyo"
-        pycache_pyc = imp.cache_from_source(file_py, True)
-        pycache_pyo = imp.cache_from_source(file_py, False)
+        pycache_pyc = importlib.util.cache_from_source(file_py, True)
+        pycache_pyo = importlib.util.cache_from_source(file_py, False)
         if self._optimize == -1:
             # legacy mode: use whatever file is present
             if (os.path.isfile(file_pyo) and

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django>=1.10,<2.2; python_version >= '3.4'
+Django>=2.2,<2.3; python_version >= '3.4'
 Pillow>=2.9.0
 apscheduler>=3.3.0
 #django-constance[database]>=2.1


### PR DESCRIPTION
* Update Django to 2.2

  Signature of gettext_module.translation() changed and Django 2.2 is using the
  new version without `codeset`.

  https://stackoverflow.com/questions/74406706/typeerror-translation-got-an-unexpected-keyword-argument-codeset

* migrate imp -> importlib

  Used the following correspondence table:
  https://docs.python.org/3/whatsnew/3.12.html#whatsnew312-removed-imp